### PR TITLE
Only show the options page on initial install

### DIFF
--- a/src/background/events.js
+++ b/src/background/events.js
@@ -470,8 +470,10 @@ chrome.tabs.onActivated.addListener(function (info) {
 });
 
 // Opens the options page on extension install
-chrome.runtime.onInstalled.addListener(function (object) {
-  chrome.runtime.openOptionsPage((result) => {});
+chrome.runtime.onInstalled.addListener(function (details) {
+  if (details.reason === 'install') {
+    chrome.runtime.openOptionsPage((result) => {});
+  }
 });
 
 


### PR DESCRIPTION
The `onInstalled` event is triggered on extension install, extension update, and Chrome update, which can be very annoying because the options page pops up and you are presented with the tutorial that must be dismissed. This PR changes it so the options page is only launched when the extension is first installed.

Fixes #206