### PR TITLE
Fixed analysis mode exporting two csv files (Issue-#363)

### DIFF
--- a/src/options/views/settings-view/settings-view.js
+++ b/src/options/views/settings-view/settings-view.js
@@ -138,6 +138,7 @@ async function createMessageListeners(){
   chrome.runtime.onMessage.addListener(function (message, _, __) {
     if (message.msg === "CSV_DATA_RESPONSE_TO_SETTINGS") {
       csvGenerator(csvData, message.data.titles);
+      return
     }
   });
 }

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -937,16 +937,15 @@ chrome.runtime.onMessage.addListener(function (message, _, __) {
     let data = analysis_userend[parsedDomain] || {};
     buildAnalysis(data);
   }
-  createMessageListeners()
+  if (message.msg === "CSV_DATA_RESPONSE") {
+    const csvData = fetchcsvData();
+    csvData.then((csvData) => csvGenerator(csvData, message.data.titles));
+  }
 });
 
-async function createMessageListeners(){
+async function fetchcsvData(){
   const csvData = await storage.getStore(stores.analysis)
-  chrome.runtime.onMessage.addListener(function (message, _, __) {
-    if (message.msg === "CSV_DATA_RESPONSE") {
-      csvGenerator(csvData, message.data.titles);
-    }
-  });
+  return csvData
 }
 
 // Initializes the process to add to domainlist, via the background script


### PR DESCRIPTION
To review this, first check the extension just downloads one copy of csv file upon clicking the download button from popup or settings page. Second, disable and reenable the extension from firefox's settings page, then download the csv file again and check we still have all analysis data.