### PR TITLE
change updateDomainlist functions so 3rd parties are correctly s…

### DIFF
--- a/src/background/protection/protection-ff.js
+++ b/src/background/protection/protection-ff.js
@@ -21,6 +21,7 @@ import { initCookiesPerDomain } from "./cookiesOnInstall.js";
 import { initCookiesOnInstall } from "./cookiesOnInstall.js";
 import psl from "psl";
 import { addDynamicRule, deleteDynamicRule } from "../../common/editRules"
+//import { getCurrentParsedDomain } from "../../popup/popup.js";
 
 
 
@@ -39,7 +40,8 @@ var signalPerTab = {};  // Caches if a signal is sent to render the popup icon
 var activeTabID = 0;    // Caches current active tab id
 var sendSignal = true;  // Caches if the signal can be sent to the curr domain
 var isFirefox = ("$BROWSER" === "firefox");
-
+var domPrev3rdParties = {}; //stores all the 3rd parties by domain (resets when you quit chrome)
+var globalParsedDomain;
 
 async function reloadVars() {
   let storedDomainlisted = await storage.get(stores.settings, "IS_DOMAINLISTED");
@@ -149,16 +151,34 @@ function addHeaders(details) {
   });
 }
 
+function getCurrentParsedDomain() {
+  return new Promise((resolve, reject) => {
+    try {
+      chrome.tabs.query({ active: true, currentWindow: true }, function (tabs) {
+        let tab = tabs[0];
+        let url = new URL(tab.url);
+        let parsed = psl.parse(url.hostname);
+        let domain = parsed.domain;
+        globalParsedDomain = domain;  // for global scope variable
+        resolve(domain);
+      });
+    } catch(e) {
+      reject();
+    }
+  })
+}
+
 /**
  * Checks whether a particular domain should receive a DNS signal
  * (1) Parse url to get domain for domainlist
  * (2) Update domains by adding current domain to domainlist in storage.
- * (3) Check to see if we should send signal.
+ * (3) Updates the 3rd party list for the currentDomain
+ * (4) Check to see if we should send signal.
  * 
  * Currently, it only adds to domainlist store as NULL if it doesnt exist
  * @param {Object} details - callback object according to Chrome API
  */
- function updateDomainlist(details) {
+ async function updateDomainlist(details) {
   let url = new URL(details.url);
   let parsedUrl = psl.parse(url.hostname);
   let parsedDomain = parsedUrl.domain;
@@ -172,7 +192,21 @@ function addHeaders(details) {
     domainlist[parsedDomain] = null;                    // Sets to cache
     parsedDomainVal = null;
   }
+
+  //get the current parsed domain--this is used to store 3rd parties (using globalParsedDomain variable)
+ 
+  let currentDomain = await getCurrentParsedDomain(); 
+  //initialize the objects
+  if (!(activeTabID in domPrev3rdParties)){
+    domPrev3rdParties[activeTabID] = {};
+  }
+  if (!(currentDomain in domPrev3rdParties[activeTabID]) ){
+    domPrev3rdParties[activeTabID][currentDomain] = {};
+  }
+  //as they come in, add the parsedDomain to the object with null value (just a placeholder)
+  domPrev3rdParties[activeTabID][currentDomain][parsedDomain] = null;
   
+
   (isDomainlisted) 
     ? ((parsedDomainVal === null) ? sendSignal = true : sendSignal = false)
     : sendSignal = true;
@@ -312,10 +346,13 @@ function handleSendMessageError() {
 
 // Info back to popup
 function dataToPopup() {
-  let requestsData = {};
 
+  let requestsData = {};  
+  
   if (tabs[activeTabID] !== undefined) {
-    requestsData = tabs[activeTabID].REQUEST_DOMAINS;
+
+    requestsData = domPrev3rdParties[activeTabID][globalParsedDomain];
+    console.log("requests by tabID:", domPrev3rdParties);
   }
 
   chrome.tabs.query({active: true, currentWindow: true}, function(tabs){

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -121,7 +121,7 @@ function generateDarkmodeElement() {
 
 
 // Fetches the current domain 
-function getCurrentParsedDomain() {
+export function getCurrentParsedDomain() {
   return new Promise((resolve, reject) => {
     try {
       chrome.tabs.query({ active: true, currentWindow: true }, function (tabs) {
@@ -557,7 +557,7 @@ async function buildDomains(requests) {
   let items = "";
   const domainlistKeys = await storage.getAllKeys(stores.domainlist)
   const domainlistValues = await storage.getAll(stores.domainlist)
-
+  
   // Sets the 3rd party domain elements
   for (let requestDomain in requests) {
     if (requestDomain != domain){
@@ -621,6 +621,7 @@ async function buildDomains(requests) {
     addThirdPartyDomainDNSToggleListener(requestDomain)
     }
   }
+
 
 
 }


### PR DESCRIPTION
…rd parties in popup

I added the getCurrentParsedDomain function from popup.js to both protection files because if I imported it, the popup seemed to change to analysis mode (in chrome and firefox)

3rd parties are now stored as they come using the updateDomainList function