### PR TITLE
Issue 443, fixed github logout issue

### DIFF
--- a/src/background/protection/cookiesOnInstall.js
+++ b/src/background/protection/cookiesOnInstall.js
@@ -22,6 +22,7 @@ function initCookiesPerDomain(domainFilter) {
 
 function deleteCookiesPerDomain(domainFilter) {
   deleteFilteredCookies(cookie_list, domainFilter);
+  console.log("Deletecookiesperdomain called. DF:  ", domainFilter);
 }
 
 /**
@@ -148,6 +149,12 @@ function setFilteredCookies(cookies, domainFilter) {
         // Deletes cookie url based on domain, checks for domain/subdomain spec
         let cookieUrl = cookies[item].domain;
         let name = cookies[item].name;
+
+        if (cookieUrl.substr(0, 1) === ".") {
+          cookieUrl = cookieUrl.substr(1);
+        }
+        
+        cookieUrl = `https://${cookieUrl}/`;
 
         chrome.cookies.remove({
           url: cookieUrl,

--- a/src/background/protection/cookiesOnInstall.js
+++ b/src/background/protection/cookiesOnInstall.js
@@ -20,6 +20,10 @@ function initCookiesPerDomain(domainFilter) {
   setFilteredCookies(cookie_list, domainFilter);
 }
 
+function deleteCookiesPerDomain(domainFilter) {
+  deleteFilteredCookies(cookie_list, domainFilter);
+}
+
 /**
  * Sets a cookie at the given domain for each cookie in the passed in
  * cookies object. Currently updates cookie url info based on domain.
@@ -126,9 +130,38 @@ function setFilteredCookies(cookies, domainFilter) {
   }
 }
 
+/**
+ * Sets a cookie at the given domain for each item in the passed in
+ * cookies object. Currently updates cookie url info based on domain.
+ * @param {Object} cookies - Collection of info regarding each 3rd
+ *                           party cookie to be set
+ * Each item in `cookies` must contain a 'name', 'value', and 'domain'
+ */
+ function deleteFilteredCookies(cookies, domainFilter) {
+
+  for (let item in cookies) {
+    for (let domain in domainFilter) {
+      // Notice that this `if` will trigger only for sites mentioned in our
+      // cookies, i.e. primarily only adtech websites since all our cookies
+      // are adtech opt outs
+      if (domainFilter[domain] == cookies[item].domain) {
+        // Deletes cookie url based on domain, checks for domain/subdomain spec
+        let cookieUrl = cookies[item].domain;
+        let name = cookies[item].name;
+
+        chrome.cookies.remove({
+          url: cookieUrl,
+          name: name,
+        });
+      }
+    }
+  }
+}
+
 export {
   initCookiesOnInstall,
   initCookiesPerDomain,
+  deleteCookiesPerDomain,
   setAllCookies,
   setFilteredCookies,
 };

--- a/src/background/protection/protection-ff.js
+++ b/src/background/protection/protection-ff.js
@@ -99,8 +99,8 @@ const listenerCallbacks = {
    * @param {object} details - retrieved info passed into callback
    */
   onCommitted: async (details) => {
+    initIAB(sendSignal);
     if (sendSignal) {
-      initIAB();
       addDomSignal(details);
       updatePopupIcon(details);
     }
@@ -463,9 +463,12 @@ async function onMessageHandlerAsync(message, sender, sendResponse) {
       tabs[tabID]["TIMESTAMP"] = message.data;
     }
   }
-  if (message.msg === "SET_OPTOUT_COOKEIS") {
+  if (message.msg === "SET_OPTOUT_COOKIES") {
     // This is specifically for when cookies are removed when a user turns off
     // do not sell for a particular site, and chooses to re-enable it
+    initCookiesPerDomain(message.data);
+  }
+  if (message.msg === "DELETE_OPTOUT_COOKIES") {
     initCookiesPerDomain(message.data);
   }
   if (message.msg === "FORCE_RELOAD") {

--- a/src/background/protection/protection-ff.js
+++ b/src/background/protection/protection-ff.js
@@ -15,7 +15,7 @@ import { defaultSettings } from "../../data/defaultSettings.js";
 import { headers } from "../../data/headers.js";
 import { enableListeners, disableListeners } from "./listeners-$BROWSER.js";
 import { initIAB } from "../cookiesIAB.js";
-import { initCookiesPerDomain } from "./cookiesOnInstall.js";
+import { initCookiesPerDomain, deleteCookiesPerDomain } from "./cookiesOnInstall.js";
 import { initCookiesOnInstall } from "./cookiesOnInstall.js";
 import psl from "psl";
 
@@ -469,7 +469,7 @@ async function onMessageHandlerAsync(message, sender, sendResponse) {
     initCookiesPerDomain(message.data);
   }
   if (message.msg === "DELETE_OPTOUT_COOKIES") {
-    initCookiesPerDomain(message.data);
+    deleteCookiesPerDomain(message.data);
   }
   if (message.msg === "FORCE_RELOAD") {
     pullToDomainlistCache();

--- a/src/background/protection/protection.js
+++ b/src/background/protection/protection.js
@@ -14,7 +14,7 @@ import { stores, storage } from "./../storage.js";
 import { defaultSettings } from "../../data/defaultSettings.js";
 import { enableListeners, disableListeners } from "./listeners-$BROWSER.js";
 import { initIAB } from "../cookiesIAB.js";
-import { initCookiesPerDomain } from "./cookiesOnInstall.js";
+import { initCookiesPerDomain, deleteCookiesPerDomain } from "./cookiesOnInstall.js";
 import { initCookiesOnInstall } from "./cookiesOnInstall.js";
 import psl, { parse } from "psl";
 
@@ -405,11 +405,10 @@ async function onMessageHandlerAsync(message, sender, sendResponse) {
 
     wellknown[tabID] = message.data;
     let wellknownData = message.data;
+    initIAB(!sendSignal);
     if (wellknown[tabID] === null && sendSignal == null) {
-      initIAB();
       updatePopupIcon(tabID);
     } else if (wellknown[tabID]["gpc"] === true && sendSignal == null) {
-      initIAB();
       chrome.action.setIcon({
         tabId: tabID,
         path: "assets/face-icons/optmeow-face-circle-green-128.png",
@@ -446,7 +445,7 @@ async function onMessageHandlerAsync(message, sender, sendResponse) {
       tabs[tabID]["TIMESTAMP"] = message.data;
     }
   }
-  if (message.msg === "SET_OPTOUT_COOKEIS") {
+  if (message.msg === "SET_OPTOUT_COOKIES") {
     // This is initialized when cookies are to be reset to a page after
     // do not sell is turned back on (e.g., when its turned on from the popup).
 
@@ -454,6 +453,10 @@ async function onMessageHandlerAsync(message, sender, sendResponse) {
     // do not sell for a particular site, and chooses to re-enable it
     initCookiesPerDomain(message.data);
   }
+  if (message.msg === "DELETE_OPTOUT_COOKIES") {
+    deleteCookiesPerDomain(message.data);
+  }
+
   return true; // Async callbacks require this
 }
 

--- a/src/background/protection/protection.js
+++ b/src/background/protection/protection.js
@@ -454,6 +454,7 @@ async function onMessageHandlerAsync(message, sender, sendResponse) {
     initCookiesPerDomain(message.data);
   }
   if (message.msg === "DELETE_OPTOUT_COOKIES") {
+    console.log("Msg received. Info; ", message.data);
     deleteCookiesPerDomain(message.data);
   }
 

--- a/src/background/storageCookies.js
+++ b/src/background/storageCookies.js
@@ -27,26 +27,30 @@ export const storageCookies = {
     // Since this can run anywhere (popup, settings, background),
     // we must tell the background to set our correct optout cookies
     chrome.runtime.sendMessage({
-      msg: "SET_OPTOUT_COOKEIS",
+      msg: "SET_OPTOUT_COOKIES",
       data: domainFilter,
     });
   },
 
   async deleteCookiesForGivenDomain(domainKey) {
-    let cookieArr = [];
-    chrome.cookies.getAll({ domain: `${domainKey}` }, function (cookies) {
-      cookieArr = cookies;
+    let domainFilter;
+    if (domainKey.substr(0, 1) === ".") {
+      domainFilter = [
+        domainKey.substr(1),
+        domainKey,
+        `www${domainKey.substr(1)}`,
+      ];
+    } else if (domainKey.substr(0, 1) === "w") {
+      domainFilter = [domainKey.substr(3), domainKey.substr(4), domainKey];
+    } else {
+      domainFilter = [domainKey, `.${domainKey}`, `www.${domainKey}`];
+    }
 
-      for (let i in cookieArr) {
-        chrome.cookies.remove({
-          url: `https://${domainKey}/`,
-          name: cookieArr[i].name,
-        });
-        chrome.cookies.remove({
-          url: `https://www.${domainKey}/`,
-          name: cookieArr[i].name,
-        });
-      }
+    // Since this can run anywhere (popup, settings, background),
+    // we must tell the background to set our correct optout cookies
+    chrome.runtime.sendMessage({
+      msg: "DELETE_OPTOUT_COOKIES",
+      data: domainFilter,
     });
-  },
+  }
 };

--- a/src/background/storageCookies.js
+++ b/src/background/storageCookies.js
@@ -52,5 +52,6 @@ export const storageCookies = {
       msg: "DELETE_OPTOUT_COOKIES",
       data: domainFilter,
     });
+    console.log("Delete message sent");
   }
 };

--- a/test/background/parseIAB.test.js
+++ b/test/background/parseIAB.test.js
@@ -15,17 +15,23 @@ import { parseIAB } from "../../src/background/cookiesIAB.js";
 
 describe("Check parsing of IAB signal", () => {
     it('Should parse invalid signal to 1NYN', () => {
-        assert.equal(parseIAB("1WYY"), '1NYN');
+        assert.equal(parseIAB("1WYY", true), '1NYN');
     });
 
     it('Should parse valid signal 1--- to 1YYY', () => {
-        assert.equal(parseIAB("1---"), '1YYY');
+        assert.equal(parseIAB("1---",true ), '1YYY');
     });
 
     it('Should change third char in valid signal to Y', () => {
-        assert.equal(parseIAB("1NNN"), '1NYN');
-        assert.equal(parseIAB("1YNY"), '1YYY');
-        assert.equal(parseIAB("1NNY"), '1NYY');
+        assert.equal(parseIAB("1NNN", true), '1NYN');
+        assert.equal(parseIAB("1YNY", true), '1YYY');
+        assert.equal(parseIAB("1NNY", true), '1NYY');
+    });
+
+    it('Should change third char in valid signal to N', () => {
+        assert.equal(parseIAB("1NYN", true), '1NNN');
+        assert.equal(parseIAB("1YYN", true), '1YNN');
+        assert.equal(parseIAB("1YYY", true), '1YNY');
     });
     
 }) 

--- a/test/background/parseIAB.test.js
+++ b/test/background/parseIAB.test.js
@@ -29,9 +29,9 @@ describe("Check parsing of IAB signal", () => {
     });
 
     it('Should change third char in valid signal to N', () => {
-        assert.equal(parseIAB("1NYN", true), '1NNN');
-        assert.equal(parseIAB("1YYN", true), '1YNN');
-        assert.equal(parseIAB("1YYY", true), '1YNY');
+        assert.equal(parseIAB("1NYN", false), '1NNN');
+        assert.equal(parseIAB("1YYN", false), '1YNN');
+        assert.equal(parseIAB("1YYY", false), '1YNY');
     });
     
 }) 


### PR DESCRIPTION
This should all be dealt with.

On your end, can you check if two things are working:

1. Go to `https://global-privacy-control.glitch.me/`, the DOM signal and header should still be being sent.
2. Inspect the page and look at the cookies, is there a usprivacy string cookie with the value `1NYN`? (there should be)
3. Using the popup, opt back in to sales then reload the page.
4. The DOM signal and header should not be sent anymore.
5. The usprivacy string cookie should still be there but with `1NNN`
6. Navigate to `https://www.33across.com/`
7. In the cookies, there should be a cookie named `33x_nc` with the value `33Across+Optout`
8. If you opt in to that site, that cookie should be deleted
9. If you opt out of that site again, the cookie should reappear
10. Finally, try to replicate the github issue again and you should not be logged out

Please try to do these checks for both Chrome and Firefox