### PR TITLE
fix: broken \"Learn More About Us\" link (404)

### DIFF
--- a/src/options/views/settings-view/settings-view.js
+++ b/src/options/views/settings-view/settings-view.js
@@ -227,7 +227,7 @@ function walkthrough() {
     modal.show();
     document.getElementById("modal-button-3").onclick = () => {
       chrome.tabs.create(
-        { url: "https://privacytechlab.org/optmeowt" },
+        { url: "https://privacytechlab.org/" },
         function (tab) { }
       );
     };


### PR DESCRIPTION
## Fix

The "Learn More About Us" button in the tutorial walkthrough modal (`settings-view.js`, line 230) links to `https://privacytechlab.org/optmeowt` which returns a 404. Updated to `https://privacytechlab.org/`.

One line, one URL. That's it.

Fixes #540

---

🇺🇸 Reid Wiseman — Commander
🇺🇸 Victor Glover — Pilot
🇺🇸 Christina Koch — Mission Specialist
🇨🇦 Jeremy Hansen — Mission Specialist

Artemis II. Privacy is a human right — on this planet and beyond it.