### PR TITLE
Add GPC Web UI link to popup

### DIFF
--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -161,6 +161,16 @@ popup.html is the html scaffolding for OptMeowt's popup page
       </div>
 
       <hr id="divider-10" class="divide" style="margin: 0px" />
+
+      <!-- GPC Web UI link -->
+      <div id="gpc-web-ui-link" uk-grid class="domain-list" style="padding: 15px; margin-right: -30px">
+        <div class="uk-width-expand uk-text-center"
+          style="font-weight: bold; font-size: medium; margin-right: 20px">
+          See Web Compliance Data
+        </div>
+      </div>
+
+      <hr class="divide" style="margin: 0px" />
       <!-- Dark Mode -->
       <div uk-grid class="uk-margin-top" style="margin-bottom: 4%">
         <div class="uk-width-expand uk-margin-auto-vertical" style="font-weight: bold; font-size: medium">

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -413,6 +413,7 @@ async function showProtectionInfo() {
   document.getElementById("divider-7").style.display = "none";
   document.getElementById("visited-domains-stats").style.display = "";
   document.getElementById("domain-list").style.display = "";
+  document.getElementById("gpc-web-ui-link").style.display = "";
 
   const wellknownCheckEnabled = await isWellknownCheckEnabled();
   document.getElementById("dropdown-2").style.display = wellknownCheckEnabled
@@ -945,4 +946,15 @@ if ("$BROWSER" == "chrome") {
 document.getElementById("domain-list").addEventListener("click", async () => {
   await storage.set(stores.settings, true, "DOMAINLIST_PRESSED");
   chrome.runtime.openOptionsPage();
+});
+
+// Listener: Opens GPC Web UI with current domain and user's selected state
+document.getElementById("gpc-web-ui-link").addEventListener("click", async () => {
+  const userState = await getUserState();
+  const stateParam = userState && userState !== "none" ? `&state=${userState}` : "";
+  if (parsedDomain) {
+    chrome.tabs.create({ url: `https://gpc-web-ui.vercel.app/?url=${parsedDomain}${stateParam}` });
+  } else {
+    chrome.tabs.create({ url: `https://gpc-web-ui.vercel.app/${stateParam ? `?${stateParam.slice(1)}` : ""}` });
+  }
 });


### PR DESCRIPTION
Adds a new 'See Web Compliance Data' link to the extension popup UI and ensures it is shown when protection info is displayed. Clicking the link opens the GPC Web UI in a new tab, passing the current parsed domain as the url parameter and appending the user's selected state if available. Handles the case where no domain is parsed by opening the GPC Web UI without a url parameter.