### PR TITLE
Show per-privacy string compliance classifications in popup

### DIFF
--- a/src/data/complianceData.js
+++ b/src/data/complianceData.js
@@ -22,6 +22,12 @@ The 8 signal columns checked for null:
   usp_cookies_before_gpc, usp_cookies_after_gpc,
   OptanonConsent_before_gpc, OptanonConsent_after_gpc,
   gpp_before_gpc, gpp_after_gpc
+
+When the all_sites CSV includes a `compliance_classification` column (per the
+schema in gpc-web-ui at client/background_reading/COMPLIANCE_CLASSIFICATION_OVERVIEW.md
+— https://github.com/privacy-tech-lab/gpc-web-ui/blob/master/client/background_reading/COMPLIANCE_CLASSIFICATION_OVERVIEW.md),
+the parsed JSON object is attached to each domain entry as `classification` so
+the popup can show per-family status (USPS, OptanonConsent, Well-known, GPP).
 */
 
 const STATES_JSON_URL =
@@ -94,6 +100,63 @@ function isNullSignal(val) {
 }
 
 /**
+ * Parses a single CSV line, honoring double-quote-wrapped fields with `""`
+ * escapes. Required because some columns (urlClassification, third_party_urls,
+ * compliance_classification, …) contain quoted JSON with embedded commas.
+ * Naive `line.split(',')` mis-aligns columns past the first quoted field.
+ * Assumes no embedded newlines inside quoted fields, which holds for these CSVs.
+ * @param {string} line
+ * @returns {string[]}
+ */
+function parseCSVLine(line) {
+  const out = [];
+  let cur = '';
+  let inQuotes = false;
+  for (let i = 0; i < line.length; i++) {
+    const ch = line[i];
+    if (inQuotes) {
+      if (ch === '"') {
+        if (line[i + 1] === '"') { cur += '"'; i++; }
+        else { inQuotes = false; }
+      } else {
+        cur += ch;
+      }
+    } else if (ch === ',') {
+      out.push(cur); cur = '';
+    } else if (ch === '"' && cur === '') {
+      inQuotes = true;
+    } else {
+      cur += ch;
+    }
+  }
+  out.push(cur);
+  return out;
+}
+
+/**
+ * Parses the `compliance_classification` field, which the upstream crawler
+ * currently emits as a Python repr (single quotes, None/True/False) rather
+ * than real JSON. We coerce to JSON before parsing so the field is usable.
+ * Returns null if the value can't be parsed under either dialect.
+ *
+ * TODO: the blind `'` → `"` replace will mangle any string value that contains
+ * an apostrophe. Today the schema only carries enum statuses with no free-form
+ * strings, so this is safe, but the real fix is upstream: have the crawler
+ * emit real JSON (json.dumps) instead of a Python repr in this column.
+ * @param {string} raw
+ * @returns {object|null}
+ */
+function parseClassification(raw) {
+  try { return JSON.parse(raw); } catch (_) {}
+  const jsonish = raw
+    .replace(/\bNone\b/g, 'null')
+    .replace(/\bTrue\b/g, 'true')
+    .replace(/\bFalse\b/g, 'false')
+    .replace(/'/g, '"');
+  try { return JSON.parse(jsonish); } catch (_) { return null; }
+}
+
+/**
  * Fetches a CSV from the given URL and returns a Set of domain strings.
  * Used for the noncompliant_sites CSV where we only need domain membership.
  * Assumes a column header named "domain" (case-insensitive).
@@ -138,11 +201,14 @@ async function fetchDomainSet(url) {
 }
 
 /**
- * Fetches the all_sites CSV and returns a Map of domain → { allNull: boolean }.
- * allNull is true when all 8 privacy-signal columns are null/empty, meaning
- * we could not observe any consent mechanism to measure GPC compliance against.
+ * Fetches the all_sites CSV and returns a Map of domain →
+ *   { allNull: boolean, classification: object|null }.
+ * - allNull is true when all 8 privacy-signal columns are null/empty, meaning
+ *   we could not observe any consent mechanism to measure GPC compliance against.
+ * - classification is the parsed `compliance_classification` JSON object when
+ *   the column is present and parseable, otherwise null.
  * @param {string} url - Direct download URL for the all_sites CSV
- * @returns {Promise<Map<string, {allNull: boolean}>>}
+ * @returns {Promise<Map<string, {allNull: boolean, classification: object|null}>>}
  */
 async function fetchAllSitesData(url) {
   const response = await fetch(url);
@@ -159,7 +225,7 @@ async function fetchAllSitesData(url) {
   const lines = csvText.split(/\r?\n/);
   if (lines.length < 2) return new Map();
 
-  const headers = lines[0].split(',').map(h => h.trim().toLowerCase());
+  const headers = parseCSVLine(lines[0]).map(h => h.trim().toLowerCase());
   const domainIndex = headers.indexOf('domain');
   if (domainIndex === -1) {
     throw new Error('all_sites CSV does not contain a "domain" column');
@@ -167,12 +233,13 @@ async function fetchAllSitesData(url) {
 
   // Map each signal column name to its index (-1 if not present)
   const signalIndices = SIGNAL_COLUMNS.map(col => headers.indexOf(col));
+  const classificationIndex = headers.indexOf('compliance_classification');
 
   const result = new Map();
   for (let i = 1; i < lines.length; i++) {
-    const line = lines[i].trim();
-    if (!line) continue;
-    const cols = line.split(',');
+    const line = lines[i];
+    if (!line || !line.trim()) continue;
+    const cols = parseCSVLine(line);
     const domain = cols[domainIndex] ? cols[domainIndex].trim() : null;
     // Skip rows where domain itself is missing or the literal string "null"
     // (happens when the crawler couldn't resolve the domain, e.g. status="not added")
@@ -180,7 +247,16 @@ async function fetchAllSitesData(url) {
 
     // A domain is allNull only if every signal column is null/empty
     const allNull = signalIndices.every(idx => idx === -1 || isNullSignal(cols[idx]));
-    result.set(domain, { allNull });
+
+    let classification = null;
+    if (classificationIndex !== -1) {
+      const raw = cols[classificationIndex];
+      if (raw && raw.trim() && raw.trim().toLowerCase() !== 'null') {
+        classification = parseClassification(raw);
+      }
+    }
+
+    result.set(domain, { allNull, classification });
   }
 
   return result;
@@ -249,24 +325,21 @@ export async function fetchComplianceData(stateCode) {
 
   const complianceMap = {};
 
-  for (const [domain, { allNull }] of allSitesData) {
+  for (const [domain, { allNull, classification }] of allSitesData) {
+    let status;
     if (noncompliantDomains.has(domain)) {
-      complianceMap[domain] = {
-        status: 'non_compliant',
-        details: '',
-      };
+      status = 'non_compliant';
     } else if (allNull) {
       // All 8 signal columns were null during the crawl — we can't assess compliance
-      complianceMap[domain] = {
-        status: 'no_signals',
-        details: '',
-      };
+      status = 'no_signals';
     } else {
-      complianceMap[domain] = {
-        status: 'compliant',
-        details: '',
-      };
+      status = 'compliant';
     }
+    complianceMap[domain] = {
+      status,
+      details: '',
+      classification, // null when CSV lacks the column or value is JSON null
+    };
   }
 
   return {

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -210,7 +210,7 @@ async function renderDomainCounter() {
   }).length;
   document.getElementById("visited-domains-stats").innerHTML = `
     <p id = "domain-count" class="blue-heading" style="font-size:25px;
-    font-weight: bold">${count}</p> domains receiving signals
+    font-weight: bold">${count}</p> Domains Receiving Signals
   `;
 }
 
@@ -762,6 +762,85 @@ async function buildComplianceStatusLoading(stateCode) {
   `;
 }
 
+// Maps a schema status string to a (label, css class) for the status pill.
+// `null`/missing means no privacy string of that family was detected.
+const CLASSIFICATION_STATUS_META = {
+  opted_out:        { label: 'Opted Out',        cls: 'status-opted-out' },
+  did_not_opt_out:  { label: 'Did Not Opt Out',  cls: 'status-did-not-opt-out' },
+  invalid_missing:  { label: 'Invalid/Missing',  cls: 'status-invalid' },
+  invalid:          { label: 'Invalid',          cls: 'status-invalid' },
+  not_applicable:   { label: 'Not Applicable',   cls: 'status-na' },
+};
+const CLASSIFICATION_NONE_META  = { label: 'None',  cls: 'status-none' };
+const CLASSIFICATION_MIXED_META = { label: 'Mixed', cls: 'status-mixed' };
+
+function metaForStatus(status) {
+  if (!status) return CLASSIFICATION_NONE_META;
+  // Fallback label is a fixed string (not `status`) so unexpected/malformed
+  // values from the CSV can't be injected into innerHTML downstream.
+  return CLASSIFICATION_STATUS_META[status] || { label: 'Unknown', cls: 'status-none' };
+}
+
+// GPP ships a list of per-(state, field) classifications. Collapse to one
+// status: same across all → that status; different → "Mixed".
+function aggregateGppMeta(gpp) {
+  if (!gpp || !Array.isArray(gpp.classifications) || gpp.classifications.length === 0) {
+    return CLASSIFICATION_NONE_META;
+  }
+  const statuses = new Set(gpp.classifications.map(c => c.status));
+  if (statuses.size === 1) return metaForStatus([...statuses][0]);
+  return CLASSIFICATION_MIXED_META;
+}
+
+function classificationRowHtml(family, meta) {
+  return `
+    <div class="classification-row">
+      <span class="classification-family">${family}</span>
+      <span class="classification-status ${meta.cls}">${meta.label}</span>
+    </div>
+  `;
+}
+
+function buildClassificationHtml(classification) {
+  return `
+    <div class="compliance-classifications">
+      ${classificationRowHtml('USPS',            metaForStatus(classification.usps?.status))}
+      ${classificationRowHtml('Optanon Consent', metaForStatus(classification.optanonConsent?.status))}
+      ${classificationRowHtml('Well-known',      metaForStatus(classification.wellKnown?.status))}
+      ${classificationRowHtml('GPP',             aggregateGppMeta(classification.gpp))}
+    </div>
+  `;
+}
+
+// Roll the four families (GPP flattened) into a single top-line verdict:
+// any did_not_opt_out → "does_not_honor"; else any opted_out → "honors";
+// else "unknown" (all None, or only invalid/not_applicable).
+function computeOverallVerdict(classification) {
+  const statuses = [];
+  if (classification.usps?.status)            statuses.push(classification.usps.status);
+  if (classification.optanonConsent?.status)  statuses.push(classification.optanonConsent.status);
+  if (classification.wellKnown?.status)       statuses.push(classification.wellKnown.status);
+  if (Array.isArray(classification.gpp?.classifications)) {
+    for (const c of classification.gpp.classifications) {
+      if (c.status) statuses.push(c.status);
+    }
+  }
+  if (statuses.includes('did_not_opt_out')) return 'does_not_honor';
+  if (statuses.includes('opted_out'))       return 'honors';
+  return 'unknown';
+}
+
+function overallBadgeHtml(classification) {
+  const verdict = computeOverallVerdict(classification);
+  if (verdict === 'honors') {
+    return '<span class="compliance-status-badge compliance-compliant">🟢 Likely Honors GPC</span>';
+  }
+  if (verdict === 'does_not_honor') {
+    return '<span class="compliance-status-badge compliance-non-compliant">🔴 Likely Does Not Honor GPC</span>';
+  }
+  return '<span class="compliance-status-badge compliance-no-signals">🟡 Could Not Determine</span>';
+}
+
 /**
  * Builds the Compliance Status HTML for the popup window
  * @param {Object} status - Compliance status object from storage
@@ -797,10 +876,22 @@ async function buildComplianceStatus(status, stateCode, viewUrl) {
     return;
   }
 
+  // New schema-based per-family classification (preferred when the dataset has it).
+  if (status.classification) {
+    container.innerHTML = `
+      <div class="compliance-inline">
+        ${stateLabel}
+        ${overallBadgeHtml(status.classification)}
+        ${buildClassificationHtml(status.classification)}
+        <a class="compliance-link" href="${datasetUrl}" target="_blank">View ${stateName} dataset →</a>
+      </div>
+    `;
+    return;
+  }
+
+  // Fallback: legacy summary badge for datasets without the classification column.
   let badge = '';
   let statusText = '';
-
-  //FUTURE NOTE: WE WILL NEED TO ALIGN THIS WITH OUR FUTURE COMPLIANCE CLASSIFICATIONS
   if (status.status === 'compliant') {
     badge = '<span class="compliance-status-badge compliance-compliant">🟢 Likely Honors GPC</span>';
     statusText = '';

--- a/src/popup/styles.css
+++ b/src/popup/styles.css
@@ -264,6 +264,73 @@ Compliance status indicators
 }
 
 /*
+Per-family compliance classification rows
+(USPS, Optanon Consent, Well-known, GPP)
+*/
+
+.compliance-classifications {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin: 4px 0 10px;
+  text-align: left;
+}
+
+.classification-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 12px;
+  padding: 4px 2px;
+}
+
+.classification-family {
+  font-weight: 600;
+  color: var(--text-color, inherit);
+}
+
+.classification-status {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 10px;
+  font-size: 11px;
+  font-weight: 600;
+  line-height: 1.4;
+  border: 1px solid transparent;
+}
+
+.classification-status.status-opted-out {
+  background-color: rgba(40, 167, 69, 0.15);
+  color: #2e8540;
+  border-color: rgba(40, 167, 69, 0.35);
+}
+
+.classification-status.status-did-not-opt-out {
+  background-color: rgba(220, 53, 69, 0.15);
+  color: #c0392b;
+  border-color: rgba(220, 53, 69, 0.35);
+}
+
+.classification-status.status-invalid {
+  background-color: rgba(255, 152, 0, 0.15);
+  color: #b76f00;
+  border-color: rgba(255, 152, 0, 0.35);
+}
+
+.classification-status.status-mixed {
+  background-color: rgba(0, 123, 255, 0.15);
+  color: #1565c0;
+  border-color: rgba(0, 123, 255, 0.35);
+}
+
+.classification-status.status-na,
+.classification-status.status-none {
+  background-color: rgba(120, 120, 120, 0.12);
+  color: #888;
+  border-color: rgba(120, 120, 120, 0.25);
+}
+
+/*
 State selection overlay
 */
 


### PR DESCRIPTION
Reads the new compliance_classification column from the remote csv and renders USPS / Optanon / Well-known / GPP rows and uses the schema logic instead of the extension's built-in logic whenever possible.