### PR TITLE
Bump version to 6.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "optmeowt",
-  "version": "6.1.0",
+  "version": "6.2.0",
   "description": "A privacy extension that allows users to exercise rights under GPC",
   "main": "index.js",
   "type": "module",

--- a/src/manifests/chrome/manifest-dev.json
+++ b/src/manifests/chrome/manifest-dev.json
@@ -1,7 +1,7 @@
 {
   "name": "OptMeowt",
   "author": "privacy-tech-lab",
-  "version": "6.1.0",
+  "version": "6.2.0",
   "description": "OptMeowt allows Web users to make use of their rights to opt out from the sale and sharing of personal data",
   "permissions": [
     "declarativeNetRequest",

--- a/src/manifests/chrome/manifest-dist.json
+++ b/src/manifests/chrome/manifest-dist.json
@@ -1,7 +1,7 @@
 {
   "name": "OptMeowt",
   "author": "privacy-tech-lab",
-  "version": "6.1.0",
+  "version": "6.2.0",
   "description": "OptMeowt allows Web users to make use of their rights to opt out from the sale and sharing of personal data",
   "permissions": [
     "declarativeNetRequest",

--- a/src/manifests/firefox/manifest-dev.json
+++ b/src/manifests/firefox/manifest-dev.json
@@ -1,7 +1,7 @@
 {
   "name": "OptMeowt",
   "author": "privacy-tech-lab",
-  "version": "6.1.0",
+  "version": "6.2.0",
   "description": "OptMeowt allows Web users to make use of their rights to opt out from the sale and sharing of personal data",
   "permissions": [
     "webRequestBlocking",

--- a/src/manifests/firefox/manifest-dist.json
+++ b/src/manifests/firefox/manifest-dist.json
@@ -1,7 +1,7 @@
 {
   "name": "OptMeowt",
   "author": "privacy-tech-lab",
-  "version": "6.1.0",
+  "version": "6.2.0",
   "description": "OptMeowt allows Web users to make use of their rights to opt out from the sale and sharing of personal data",
   "permissions": [
     "webRequestBlocking",


### PR DESCRIPTION
- Bumps OptMeowt from 6.1.0 to 6.2.0 across `package.json` and all four source manifests (chrome/firefox × dev/dist) following the merge of #560.
- Addresses issue #580 (update manifest after PR merge).
