### PR TITLE
Switched badges from shields.io to shieldcn (#563)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,14 @@
 <p align="center">
-  <a href="https://github.com/privacy-tech-lab/gpc-optmeowt/releases"><img alt="GitHub release (latest by date)" src="https://img.shields.io/github/v/release/privacy-tech-lab/gpc-optmeowt"></a>
-  <a href="https://github.com/privacy-tech-lab/gpc-optmeowt/releases"><img alt="GitHub Release Date" src="https://img.shields.io/github/release-date/privacy-tech-lab/gpc-optmeowt"></a>
-  <a href="https://github.com/privacy-tech-lab/gpc-optmeowt/commits/main"><img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/privacy-tech-lab/gpc-optmeowt"></a>
-  <a href="https://github.com/privacy-tech-lab/gpc-optmeowt/actions/workflows/node.js.yml"><img alt="GitHub Actions" src="https://github.com/privacy-tech-lab/gpc-optmeowt/actions/workflows/node.js.yml/badge.svg?branch=main"></a>
-  <a href="https://github.com/privacy-tech-lab/gpc-optmeowt/issues"><img alt="GitHub issues" src="https://img.shields.io/github/issues-raw/privacy-tech-lab/gpc-optmeowt"></a>
-  <a href="https://github.com/privacy-tech-lab/gpc-optmeowt/issues?q=is%3Aissue+is%3Aclosed"><img alt="GitHub closed issues" src="https://img.shields.io/github/issues-closed-raw/privacy-tech-lab/gpc-optmeowt"></a>
-  <a href="https://github.com/privacy-tech-lab/gpc-optmeowt/blob/main/LICENSE.md"><img alt="GitHub" src="https://img.shields.io/github/license/privacy-tech-lab/gpc-optmeowt"></a>
-  <a href="https://github.com/privacy-tech-lab/gpc-optmeowt/watchers"><img alt="GitHub watchers" src="https://img.shields.io/github/watchers/privacy-tech-lab/gpc-optmeowt?style=social"></a>
-  <a href="https://github.com/privacy-tech-lab/gpc-optmeowt/stargazers"><img alt="GitHub Repo stars" src="https://img.shields.io/github/stars/privacy-tech-lab/gpc-optmeowt?style=social"></a>
-  <a href="https://github.com/privacy-tech-lab/gpc-optmeowt/network/members"><img alt="GitHub forks" src="https://img.shields.io/github/forks/privacy-tech-lab/gpc-optmeowt?style=social"></a>
-  <a href="https://github.com/sponsors/privacy-tech-lab"><img alt="GitHub sponsors" src="https://img.shields.io/static/v1?label=Sponsor&message=%E2%9D%A4&logo=GitHub&color=%23fe8e86"></a>
+  <a href="https://github.com/privacy-tech-lab/gpc-optmeowt/releases"><img alt="GitHub release" src="https://shieldcn.dev/github/release/privacy-tech-lab/gpc-optmeowt.svg"></a>
+  <a href="https://github.com/privacy-tech-lab/gpc-optmeowt/commits/main"><img alt="GitHub last commit" src="https://shieldcn.dev/github/commits/privacy-tech-lab/gpc-optmeowt.svg"></a>
+  <a href="https://github.com/privacy-tech-lab/gpc-optmeowt/actions/workflows/node.js.yml"><img alt="GitHub Actions" src="https://shieldcn.dev/github/ci/privacy-tech-lab/gpc-optmeowt.svg"></a>
+  <a href="https://github.com/privacy-tech-lab/gpc-optmeowt/issues"><img alt="GitHub open issues" src="https://shieldcn.dev/github/open-issues/privacy-tech-lab/gpc-optmeowt.svg"></a>
+  <a href="https://github.com/privacy-tech-lab/gpc-optmeowt/issues?q=is%3Aissue+is%3Aclosed"><img alt="GitHub closed issues" src="https://shieldcn.dev/github/closed-issues/privacy-tech-lab/gpc-optmeowt.svg"></a>
+  <a href="https://github.com/privacy-tech-lab/gpc-optmeowt/blob/main/LICENSE.md"><img alt="GitHub license" src="https://shieldcn.dev/github/license/privacy-tech-lab/gpc-optmeowt.svg"></a>
+  <a href="https://github.com/privacy-tech-lab/gpc-optmeowt/watchers"><img alt="GitHub watchers" src="https://shieldcn.dev/github/watchers/privacy-tech-lab/gpc-optmeowt.svg"></a>
+  <a href="https://github.com/privacy-tech-lab/gpc-optmeowt/stargazers"><img alt="GitHub stars" src="https://shieldcn.dev/github/stars/privacy-tech-lab/gpc-optmeowt.svg"></a>
+  <a href="https://github.com/privacy-tech-lab/gpc-optmeowt/network/members"><img alt="GitHub forks" src="https://shieldcn.dev/github/forks/privacy-tech-lab/gpc-optmeowt.svg"></a>
+  <a href="https://github.com/sponsors/privacy-tech-lab"><img alt="GitHub sponsors" src="https://shieldcn.dev/badge/Sponsor-%E2%9D%A4-pink.svg?logo=github"></a>
 </p>
   
 <br>


### PR DESCRIPTION
Related to #563
The "unable to select next GitHub token from pool" error in the readme is a common issue with shields.io which we use for our badges. From what I can find these errors usually only last a couple of hours, and the badges are currently back up. Because the issue fixes itself fairly quickly it seems ok to leave as is, but I've still proposed an alternative solution.

Shieldcn does not seem to have the same issue with temporary outages and we could switch to it, but it does not have a release date or last commit badge. This is what's implemented in this PR, prioritizing consistency over having those two badges. If we want to leave it how it is you can just reject this pr.

The other option would be to mix badges, keeping the release date and last commit from shields.io while using shieldcn for everything else. This would have the best functionality but the two services have very different visual styles so it may look inconsistent. If you'd prefer that version, or want me to send a couple of images of what it would look like, just let me know.