### PR TITLE
Add group for major updates (issue #565)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,9 @@ updates:
         update-types:
           - minor
           - patch
+      optmeowt-major:
+        update-types:
+          - major
 
   - package-ecosystem: github-actions
     directory: /

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -18,7 +18,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Approve and enable auto-merge for patch and minor updates
-        if: steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        if: steps.metadata.outputs.dependency-group == 'optmeowt-minor-and-patch'
         run: |
           gh pr review --approve "$PR_URL"
           gh pr merge --auto --squash "$PR_URL"


### PR DESCRIPTION
### Implements the behavior discussed in #565:
Now dependabot will group and automerge the minor/patch updates. All major updates will also be grouped, but left for manual checking.

### Changes:
- Modified dependabot.yml to also group major updates
- Tweaked the auto-merge workflow to only impact the minor/patch group