### PR TITLE
Add security groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,11 +6,23 @@ updates:
       interval: weekly
     open-pull-requests-limit: 10
     groups:
+      # Groups for Version Updates
       optmeowt-minor-and-patch:
         update-types:
           - minor
           - patch
       optmeowt-major:
+        update-types:
+          - major
+          
+      # Groups for Security Updates
+      optmeowt-security-minor-and-patch:
+        applies-to: security-updates
+        update-types:
+          - minor
+          - patch
+      optmeowt-security-major:
+        applies-to: security-updates
         update-types:
           - major
 

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -17,8 +17,8 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Approve and enable auto-merge for patch and minor updates
-        if: steps.metadata.outputs.dependency-group == 'optmeowt-minor-and-patch'
+      - name: Approve and enable auto-merge for minor and patch updates
+        if: endsWith(steps.metadata.outputs.dependency-group, '-minor-and-patch')
         run: |
           gh pr review --approve "$PR_URL"
           gh pr merge --auto --squash "$PR_URL"


### PR DESCRIPTION
Implements a major group and minor/patch group for security updates. Automerge workflow was also modified to accommodate.

This was necessary as GitHub treats "security updates" and "version updates" as [fundamentally different](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#groups:~:text=Specify%20which%20type%20of%20update%20the%20group%20applies%20to%2E%20When%20undefined%2C%20defaults%20to%20version%20updates%2E%20Supported%20values%3A%20version%2Dupdates%20or%20security%2Dupdates%2E) types of updates that _need_ their own, respective groups. This will need to be done for the other repos as well.