### PR TITLE
Remove the unused domain-list handler that has a latent ReferenceError

### DIFF
--- a/src/background/protection/protection.js
+++ b/src/background/protection/protection.js
@@ -631,12 +631,6 @@ async function onMessageHandlerAsync(message, sender, sendResponse) {
     let isDomainlisted = message.data.isDomainlisted;
     storage.set(stores.settings, isDomainlisted, "IS_DOMAINLISTED");
   }
-  if (message.msg === "SET_TO_DOMAINLIST") {
-    let { domain, key } = message.data;
-    domainlist[domain] = key; // Sets to cache
-    addDynamicRule(id, domain);
-    storage.set(stores.domainlist, key, domain); // Sets to long term storage
-  }
   if (message.msg === "POPUP_PROTECTION_REQUESTS") {
     console.log("info queried");
     await dataToPopupRequests();

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -941,15 +941,6 @@ chrome.runtime.onMessage.addListener(function (message, _, __) {
   }
 });
 
-// Initializes the process to add to domainlist, via the background script
-// This is to ensure all processes happen correctly
-function setToDomainlist(d, k) {
-  chrome.runtime.sendMessage({
-    msg: "SET_TO_DOMAINLIST",
-    data: { domain: d, key: k },
-  });
-}
-
 /******************************************************************************/
 /******************************************************************************/
 /**********                  # Tutorial walkthorugh                  **********/


### PR DESCRIPTION
## What this does
Removes two pieces of dead code: `setToDomainlist()` in `popup.js` (the sender) and the `SET_TO_DOMAINLIST` handler in `background/protection/protection.js` (the receiver). Neither runs in the current extension.

## The bug (#587)
The handler called `addDynamicRule(id, domain)`, but `id` was never declared in that scope (only `domain` and `key` are). If it ran, it would throw a `ReferenceError`. As @SebastianZimmeck noted, it has no functional impact today, because the handler is unreachable.

## Why it's dead code (short history)
- In 2021, the popup added a site to the domain list by sending a `SET_TO_DOMAINLIST` message to the background. That was the original mechanism, on Manifest V2 before declarativeNetRequest existed, so the handler only cached the value and saved it to storage.
- During the Manifest V3 migration in 2022, we moved to declarativeNetRequest dynamic rules. An `addDynamicRule(...)` call was added into this old handler, but without the line that first generates a rule id (`id = await getFreshId()`). That is where the undeclared `id` came from.
- Soon after, the popup was rewired to add and remove domains by calling the helpers in `common/editDomainlist.js` directly (`addDomainToDomainlistAndRules` / `removeDomainFromDomainlistAndRules`), which do it correctly. From then on nothing sent `SET_TO_DOMAINLIST`, so the message, its sender, and its handler became leftover code.

In short, it is a leftover from the old domain-list design that the MV3 migration replaced. The bug came in during that migration and never fired because the message stopped being sent.

## Why remove instead of patch
Both the sender and the handler are unreachable, so patching the one-line bug would only fix code that never runs. Removing it is cleaner.

## What still works (for review)
Adding and removing a site on the domain list goes through `common/editDomainlist.js` (called from `popup.js` around lines 259, 262, 575, 578), which correctly does `getFreshId()` then `addDynamicRule()`. GPC signals are still sent to enabled sites and suppressed for excluded ones via the DNR rules. @mccoogp, this is the path to sanity-check.

## Note on scope
A sibling `SET_TO_DOMAINLIST` handler also exists in `protection-ff.js`, which is itself unused (tracked in #586). I left it untouched here to keep this PR focused.

Closes #587.
