### PR TITLE
Integrates schema 1.1.0 and removes legacy debt (#597)

### DIFF
--- a/src/background/protection/protection-ff.js
+++ b/src/background/protection/protection-ff.js
@@ -15,11 +15,12 @@ import { defaultSettings } from "../../data/defaultSettings.js";
 import { headers } from "../../data/headers.js";
 import { enableListeners, disableListeners } from "./listeners-$BROWSER.js";
 import psl from "psl";
-import { isWellknownCheckEnabled } from "../../common/settings.js";
+import { isWellknownCheckEnabled, getUserState } from "../../common/settings.js";
+import { fetchComplianceData, isCacheValid } from "../../data/complianceData.js";
 
 /******************************************************************************/
 /******************************************************************************/
-/**********             # Initializers (cached values)               **********/
+/********** # Initializers (cached values)               **********/
 /******************************************************************************/
 /******************************************************************************/
 
@@ -32,6 +33,12 @@ var activeTabID = 0;    // Caches current active tab id
 var sendSignal = true;  // Caches if the signal can be sent to the curr domain
 var domPrev3rdParties = {}; //stores all the 3rd parties by domain (resets when you quit chrome)
 var globalParsedDomain;
+
+const DEFAULT_COMPLIANCE_RECORD = {
+  classification: null,
+  _isMissing: true,
+  details: 'We do not have data for this site.'
+};
 
 async function reloadVars() {
   let storedDomainlisted = await storage.get(
@@ -48,7 +55,7 @@ reloadVars();
 
 /******************************************************************************/
 /******************************************************************************/
-/**********       # Lisetener callbacks - Main functionality         **********/
+/********** # Lisetener callbacks - Main functionality         **********/
 /******************************************************************************/
 /******************************************************************************/
 
@@ -102,13 +109,144 @@ const listenerCallbacks = {
       updatePopupIcon(details);
     }
   },
+
+  /**
+   * Triggers compliance check on page load completion
+   * @param {object} details - retrieved info passed into callback
+   */
+  onCompleted: async (details) => {
+    await handleComplianceCheck(details);
+  }
 }; // closes listenerCallbacks object
 
 /******************************************************************************/
 /******************************************************************************/
-/**********      # Listener helper fxns - Main functionality         **********/
+/********** # Listener helper fxns - Main functionality         **********/
 /******************************************************************************/
 /******************************************************************************/
+
+/**
+ * Fetches compliance data if not cached or cache is stale
+ * @returns {Promise<Object|null>} - Metadata map containing stateCode or null if disabled/error
+ */
+async function getComplianceData() {
+  const stateCode = await getUserState();
+  if (!stateCode || stateCode === 'none') {
+    return null;
+  }
+
+  // Check if we have valid cached data in IndexedDB
+  const metadata = await storage.get(stores.complianceData, '_metadata');
+  
+  // Invalidate cache if state changed
+  if (metadata && metadata.stateCode && metadata.stateCode !== stateCode) {
+    await storage.clear(stores.complianceData);
+  } else if (metadata && isCacheValid(metadata.fetchedAt)) {
+    return metadata; // Cache is valid, return metadata to signify readiness
+  }
+
+  // Fetch fresh data for the selected state
+  try {
+    const result = await fetchComplianceData(stateCode);
+
+    // fetchComplianceData returns { error: 'fetch_error' } on network/server failure
+    if (result.error === 'fetch_error') {
+      console.warn(`Compliance data unavailable for ${stateCode} (server/network error)`);
+      return { _fetchError: true };
+    }
+
+    // Save individual domains to indexedDB instead of holding a huge object in memory
+    const dataKeys = Object.keys(result.data);
+    for (const key of dataKeys) {
+      await storage.set(stores.complianceData, result.data[key], key);
+    }
+
+    const newMetadata = {
+      fetchedAt: result.fetchedAt,
+      count: result.count,
+      stateCode,
+    };
+    await storage.set(stores.complianceData, newMetadata, '_metadata');
+
+    // Notify the popup that fresh compliance data is ready to be painted!
+    chrome.runtime.sendMessage({
+      msg: "COMPLIANCE_DATA_READY"
+    }).catch(e => {
+      // Ignored: Popup might be closed
+    });
+
+    console.log(`Fetched ${stateCode} compliance data for ${result.count} domains`);
+    return newMetadata;
+  } catch (error) {
+    console.error('Failed to fetch compliance data:', error);
+    return null;
+  }
+}
+
+/**
+ * Looks up and stores compliance schema record for current domain after page load
+ * @param {Object} details - callback object from onCompleted listener
+ */
+async function handleComplianceCheck(details) {
+  // Only check main frame navigations
+  if (details.frameId !== 0) return;
+
+  const stateCode = await getUserState();
+  if (!stateCode || stateCode === 'none') {
+    return;
+  }
+
+  try {
+    const url = new URL(details.url);
+    const parsed = psl.parse(url.hostname);
+    const domain = parsed.domain;
+
+    if (!domain) return;
+
+    console.log('Running compliance check for:', domain);
+
+    const metadata = await storage.get(stores.complianceData, '_metadata');
+    const cacheIsCold = !metadata || !isCacheValid(metadata.fetchedAt);
+    if (cacheIsCold) {
+      await storage.set(stores.settings, true, 'COMPLIANCE_LOADING');
+      // Tell popup we are loading
+      chrome.runtime.sendMessage({ msg: "COMPLIANCE_DATA_LOADING" }).catch(() => {});
+    }
+
+   try {
+      const complianceDataMeta = await getComplianceData();
+
+      // Server/network was unreachable — store fetch error flag so popup can show it
+      if (complianceDataMeta && complianceDataMeta._fetchError) {
+        await storage.set(stores.complianceData, { classification: null, _fetchError: true }, domain);
+        return;
+      }
+
+      if (!complianceDataMeta) {
+        console.log('No compliance data available');
+        return;
+      }
+
+      const complianceRecord = await storage.get(stores.complianceData, domain) || DEFAULT_COMPLIANCE_RECORD;
+
+      console.log('Compliance record loaded for:', domain);
+
+      // Write compliance schema record to storage FIRST, then clear loading flag
+      await storage.set(stores.complianceData, complianceRecord, domain);
+    } finally {
+      // Only clear after the write above completes (or on any error path)
+      if (cacheIsCold) {
+        await storage.set(stores.settings, false, 'COMPLIANCE_LOADING');
+        // Notify popup that load is successful and store is populated
+        chrome.runtime.sendMessage({ msg: "COMPLIANCE_DATA_READY" }).catch(() => {});
+      }
+    }
+  } catch (error) {
+    console.debug('Error in compliance check:', error);
+    // Ensure loading flag is cleared on unexpected errors
+    await storage.set(stores.settings, false, 'COMPLIANCE_LOADING');
+  }
+}
 
 /**
  * Attaches headers from `headers.js` to details.requestHeaders
@@ -161,8 +299,7 @@ function getCurrentParsedDomain() {
  * (2) Update domains by adding current domain to domainlist in storage.
  * (3) Updates the 3rd party list for the currentDomain
  * (4) Check to see if we should send signal.
- * 
- * Currently, it only adds to domainlist store as NULL if it doesnt exist
+ * * Currently, it only adds to domainlist store as NULL if it doesnt exist
  * @param {Object} details - callback object according to Chrome API
  */
  async function updateDomainlist(details) {
@@ -317,7 +454,7 @@ async function sendPrivacySignal(domain) {
 
 /******************************************************************************/
 /******************************************************************************/
-/**********          # Message Passing - Popup helper fxns           **********/
+/********** # Message Passing - Popup helper fxns           **********/
 /******************************************************************************/
 /******************************************************************************/
 
@@ -360,7 +497,7 @@ function dataToPopup() {
 
 /******************************************************************************/
 /******************************************************************************/
-/**********                   # Message passing                      **********/
+/********** # Message passing                      **********/
 /******************************************************************************/
 /******************************************************************************/
 
@@ -412,6 +549,44 @@ async function onMessageHandlerAsync(message, sender, sendResponse) {
     const enabled = await isWellknownCheckEnabled();
     await chrome.storage.local.set({ WELLKNOWN_CHECK_ENABLED: enabled });
     sendResponse({ enabled });
+    return true;
+  }
+  if (message.msg === "USER_STATE_CHANGE") {
+    console.log("User state changed, triggering immediate compliance fetch...");
+
+    // Trigger fetch and update current tab
+    (async () => {
+      try {
+        // Set loading flag
+        await storage.set(stores.settings, true, "COMPLIANCE_LOADING");
+        chrome.runtime.sendMessage({ msg: "COMPLIANCE_DATA_LOADING" }).catch(() => {});
+
+        const dataMeta = await getComplianceData();
+        const tabs = await chrome.tabs.query({ active: true, currentWindow: true });
+        if (tabs.length > 0 && tabs[0].url) {
+          const url = new URL(tabs[0].url);
+          const parsed = psl.parse(url.hostname);
+          const domain = parsed.domain;
+          if (domain) {
+            // Server/network error — propagate fetch error to the popup
+            if (dataMeta && dataMeta._fetchError) {
+              await storage.set(stores.complianceData, { classification: null, _fetchError: true }, domain);
+              console.warn('Compliance config server unreachable; stored fetch error for active domain');
+            } else if (dataMeta) {
+              const complianceRecord = await storage.get(stores.complianceData, domain) || DEFAULT_COMPLIANCE_RECORD;
+              await storage.set(stores.complianceData, complianceRecord, domain);
+              console.log(`Updated compliance storage for active domain: ${domain}`);
+            }
+          }
+        }
+      } catch (e) {
+        console.error("Failed to fetch/update compliance data:", e);
+      } finally {
+        // Clear loading flag
+        await storage.set(stores.settings, false, "COMPLIANCE_LOADING");
+        chrome.runtime.sendMessage({ msg: "COMPLIANCE_DATA_READY" }).catch(() => {});
+      }
+    })();
     return true;
   }
   if (message.msg === "TOGGLE_WELLKNOWN_CHECK") {
@@ -501,7 +676,7 @@ function closeMessagePassing() {
 
 /******************************************************************************/
 /******************************************************************************/
-/**********       # Other initializers - run once per enable         **********/
+/********** # Other initializers - run once per enable         **********/
 /******************************************************************************/
 /******************************************************************************/
 
@@ -544,7 +719,7 @@ function wipeLocalVars() {
 
 /******************************************************************************/
 /******************************************************************************/
-/**********           # Exportable init / halt functions             **********/
+/********** # Exportable init / halt functions             **********/
 /******************************************************************************/
 /******************************************************************************/
 
@@ -554,7 +729,6 @@ export function init() {
   initMessagePassing();
   initSetup();
 }
-
 
 export function halt() {
   disableListeners(listenerCallbacks);

--- a/src/background/protection/protection.js
+++ b/src/background/protection/protection.js
@@ -7,7 +7,7 @@ privacy-tech-lab, https://privacytechlab.org/
 protection.js
 ================================================================================
 protection.js (1) Implements our per-site functionality for the background listeners
-          (2) Handles cached values & message passing to popup & options page
+              (2) Handles cached values & message passing to popup & options page
 */
 
 import { stores, storage } from "./../storage.js";
@@ -40,10 +40,10 @@ var domPrev3rdParties = {}; //stores all the 3rd parties by domain (resets when 
 var globalParsedDomain;
 var setup = false;
 // complianceData cache is now handled by the IndexedDB store "stores.complianceData"
-const DEFAULT_NO_DATA_STATUS = {
-  status: 'no_data',
-  details: 'We do not have data for this site.',
-  lastChecked: null
+const defaultComplianceRecord = {
+  classification: null,
+  _isMissing: true,
+  details: 'We do not have data for this site.'
 };
 
 async function reloadVars() {
@@ -182,7 +182,7 @@ async function getComplianceData() {
 }
 
 /**
- * Looks up and stores compliance status for current domain after page load
+ * Looks up and stores compliance schema record for current domain after page load
  * @param {Object} details - callback object from onCompleted listener
  */
 async function handleComplianceCheck(details) {
@@ -212,14 +212,14 @@ async function handleComplianceCheck(details) {
     }
 
     // Wrap fetch + process + store in one try/finally so COMPLIANCE_LOADING is
-    // only cleared AFTER the domain status is in storage. Clearing it earlier
+    // only cleared AFTER the record is in storage. Clearing it earlier
     // caused the popup poll to read before the write completed ("Not in Dataset").
-    try {
+   try {
       const complianceDataMeta = await getComplianceData();
 
-      // Server/network was unreachable — store fetch_error so popup can show it
+      // Server/network was unreachable — store fetch error flag so popup can show it
       if (complianceDataMeta && complianceDataMeta._fetchError) {
-        await storage.set(stores.complianceData, { status: 'fetch_error' }, domain);
+        await storage.set(stores.complianceData, { classification: null, _fetchError: true }, domain);
         return;
       }
 
@@ -228,12 +228,12 @@ async function handleComplianceCheck(details) {
         return;
       }
 
-      const status = await storage.get(stores.complianceData, domain) || DEFAULT_NO_DATA_STATUS;
+      const complianceRecord = await storage.get(stores.complianceData, domain) || defaultComplianceRecord;
 
-      console.log('Compliance status for', domain, ':', status.status);
+      console.log('Compliance record loaded for:', domain);
 
-      // Write status to storage FIRST, then clear loading flag
-      await storage.set(stores.complianceData, status, domain);
+      // Write compliance schema record to storage FIRST, then clear loading flag
+      await storage.set(stores.complianceData, complianceRecord, domain);
     } finally {
       // Only clear after the write above completes (or on any error path)
       if (cacheIsCold) {
@@ -597,14 +597,15 @@ async function onMessageHandlerAsync(message, sender, sendResponse) {
           const parsed = psl.parse(url.hostname);
           const domain = parsed.domain;
           if (domain) {
-            // Server/network error — propagate fetch_error to the popup
+            // Server/network error — propagate fetch error to the popup
             if (dataMeta && dataMeta._fetchError) {
-              await storage.set(stores.complianceData, { status: 'fetch_error' }, domain);
-              console.warn('Compliance config server unreachable; stored fetch_error for active domain');
+              await storage.set(stores.complianceData, { classification: null, _fetchError: true }, domain);
+              console.warn('Compliance config server unreachable; stored fetch error for active domain');
             } else if (dataMeta) {
-              const status = await storage.get(stores.complianceData, domain) || DEFAULT_NO_DATA_STATUS;
-              await storage.set(stores.complianceData, status, domain);
+              const complianceRecord = await storage.get(stores.complianceData, domain) || defaultComplianceRecord;
+              await storage.set(stores.complianceData, complianceRecord, domain);
               console.log(`Updated compliance storage for active domain: ${domain}`);
+              console.log("Here's what was stored:", complianceRecord)
             }
           }
         }

--- a/src/data/complianceData.js
+++ b/src/data/complianceData.js
@@ -18,9 +18,7 @@ entry as `classification` so the popup can show per-family status
 
 
 // Permalink to raw states.json — use raw.githubusercontent.com so fetch() gets JSON, not an HTML page
-// const STATES_JSON_URL = 'https://raw.githubusercontent.com/privacy-tech-lab/gpc-web-ui/master/client/public/states.json';
-const STATES_JSON_URL = 'https://raw.githubusercontent.com/KyleQ-hub/PersonalWebUI/refs/heads/main/client/public/states.json';
-// MAKE SURE TO SWAP THESE 2 CONSTANTS BEFORE THE FINAL MERGE
+const STATES_JSON_URL = 'https://raw.githubusercontent.com/privacy-tech-lab/gpc-web-ui/master/client/public/states.json';
 
 // Human-readable state names (used to look up entries in states.json)
 export const STATE_NAMES = {

--- a/src/data/complianceData.js
+++ b/src/data/complianceData.js
@@ -10,28 +10,17 @@ Fetches and processes GPC compliance data from state-specific hosted CSV files.
 CSV URLs are read dynamically from states.json hosted on GitHub so they can be
 updated server-side without requiring an extension update.
 
-Compliance is determined by set membership and signal content:
-  - Domain in noncompliant_sites        → 'non_compliant'
-  - Domain in all_sites, signals found  → 'compliant'
-  - Domain in all_sites, all signals null (nothing to measure against)   → 'no_signals'
-  - Domain in neither                   → 'no_data'  (handled by caller)
-  - Network/server error                → 'fetch_error' (handled by caller)
-
-The 8 signal columns checked for null:
-  uspapi_before_gpc, uspapi_after_gpc,
-  usp_cookies_before_gpc, usp_cookies_after_gpc,
-  OptanonConsent_before_gpc, OptanonConsent_after_gpc,
-  gpp_before_gpc, gpp_after_gpc
-
-When the all_sites CSV includes a `compliance_classification` column (per the
-schema in gpc-web-ui at client/background_reading/COMPLIANCE_CLASSIFICATION_OVERVIEW.md
-— https://github.com/privacy-tech-lab/gpc-web-ui/blob/master/client/background_reading/COMPLIANCE_CLASSIFICATION_OVERVIEW.md),
-the parsed JSON object is attached to each domain entry as `classification` so
-the popup can show per-family status (USPS, OptanonConsent, Well-known, GPP).
+Compliance is determined exclusively by the `compliance_classification` column 
+present in the all_sites CSV. The parsed JSON object is attached to each domain 
+entry as `classification` so the popup can show per-family status 
+(USPS, OptanonConsent, Well-known, GPP).
 */
 
-const STATES_JSON_URL =
-  'https://raw.githubusercontent.com/privacy-tech-lab/gpc-web-ui/master/client/public/states.json'; // Permalink to raw states.json — use raw.githubusercontent.com so fetch() gets JSON, not an HTML page
+
+// Permalink to raw states.json — use raw.githubusercontent.com so fetch() gets JSON, not an HTML page
+// const STATES_JSON_URL = 'https://raw.githubusercontent.com/privacy-tech-lab/gpc-web-ui/master/client/public/states.json';
+const STATES_JSON_URL = 'https://raw.githubusercontent.com/KyleQ-hub/PersonalWebUI/refs/heads/main/client/public/states.json';
+// MAKE SURE TO SWAP THESE 2 CONSTANTS BEFORE THE FINAL MERGE
 
 // Human-readable state names (used to look up entries in states.json)
 export const STATE_NAMES = {
@@ -41,34 +30,25 @@ export const STATE_NAMES = {
   NJ: 'New Jersey',
 };
 
-
-
 // Cache TTL: 24 hours
 const CACHE_TTL_MS = 24 * 60 * 60 * 1000;
 
 /**
  * Converts a GitHub blob URL to a raw.githubusercontent.com URL so fetch()
  * receives the raw file content rather than an HTML page.
- * e.g. https://github.com/ORG/REPO/blob/SHA/path/file.csv
- *   →  https://raw.githubusercontent.com/ORG/REPO/SHA/path/file.csv
- * @param {string} blobUrl
- * @returns {string}
  */
 function toRawUrl(blobUrl) {
-  // Handle GitHub blob URLs
   const githubMatch = blobUrl.match(
     /^https:\/\/github\.com\/([^/]+\/[^/]+)\/blob\/(.+)$/
   );
   if (githubMatch) {
     return `https://raw.githubusercontent.com/${githubMatch[1]}/${githubMatch[2]}`;
   }
-  // If it's already a raw URL or something else, return as-is
   return blobUrl;
 }
 
 /**
  * Fetches states.json from the remote host to retrieve current CSV URLs.
- * @returns {Promise<Object>} - Parsed states.json content
  */
 async function fetchStatesConfig() {
   const response = await fetch(STATES_JSON_URL);
@@ -78,36 +58,6 @@ async function fetchStatesConfig() {
   return response.json();
 }
 
-// The 8 privacy-signal column names we check for in all_sites
-const SIGNAL_COLUMNS = [
-  'uspapi_before_gpc',
-  'uspapi_after_gpc',
-  'usp_cookies_before_gpc',
-  'usp_cookies_after_gpc',
-  'optanonconsent_before_gpc',
-  'optanonconsent_after_gpc',
-  'gpp_before_gpc',
-  'gpp_after_gpc',
-];
-
-/**
- * Returns true if a column value counts as "null" (no signal present).
- * @param {string|undefined} val
- * @returns {boolean}
- */
-function isNullSignal(val) {
-  return !val || val.trim() === '' || val.trim().toLowerCase() === 'null';
-}
-
-/**
- * Parses a single CSV line, honoring double-quote-wrapped fields with `""`
- * escapes. Required because some columns (urlClassification, third_party_urls,
- * compliance_classification, …) contain quoted JSON with embedded commas.
- * Naive `line.split(',')` mis-aligns columns past the first quoted field.
- * Assumes no embedded newlines inside quoted fields, which holds for these CSVs.
- * @param {string} line
- * @returns {string[]}
- */
 function parseCSVLine(line) {
   const out = [];
   let cur = '';
@@ -133,19 +83,6 @@ function parseCSVLine(line) {
   return out;
 }
 
-/**
- * Parses the `compliance_classification` field, which the upstream crawler
- * currently emits as a Python repr (single quotes, None/True/False) rather
- * than real JSON. We coerce to JSON before parsing so the field is usable.
- * Returns null if the value can't be parsed under either dialect.
- *
- * TODO: the blind `'` → `"` replace will mangle any string value that contains
- * an apostrophe. Today the schema only carries enum statuses with no free-form
- * strings, so this is safe, but the real fix is upstream: have the crawler
- * emit real JSON (json.dumps) instead of a Python repr in this column.
- * @param {string} raw
- * @returns {object|null}
- */
 function parseClassification(raw) {
   try { return JSON.parse(raw); } catch (_) {}
   const jsonish = raw
@@ -157,58 +94,8 @@ function parseClassification(raw) {
 }
 
 /**
- * Fetches a CSV from the given URL and returns a Set of domain strings.
- * Used for the noncompliant_sites CSV where we only need domain membership.
- * Assumes a column header named "domain" (case-insensitive).
- * @param {string} url - Direct download URL for the CSV
- * @returns {Promise<Set<string>>} - Set of domain names found in the CSV
- */
-async function fetchDomainSet(url) {
-  const response = await fetch(url);
-  if (!response.ok) {
-    throw new Error(`Failed to fetch CSV (${response.status}): ${url}`);
-  }
-
-  const csvText = await response.text();
-
-  if (csvText.trim().startsWith('<!DOCTYPE html>') || csvText.includes('Google Drive - Virus scan warning')) {
-    throw new Error('CSV fetch returned HTML (possible Google Drive virus-scan redirect)');
-  }
-
-  const lines = csvText.split(/\r?\n/);
-  if (lines.length < 2) return new Set();
-
-  // Find the index of the "domain" column from the header row
-  const headers = lines[0].split(',').map(h => h.trim().toLowerCase());
-  const domainIndex = headers.indexOf('domain');
-  if (domainIndex === -1) {
-    throw new Error('CSV does not contain a "domain" column');
-  }
-
-  const domains = new Set();
-  for (let i = 1; i < lines.length; i++) {
-    const line = lines[i].trim();
-    if (!line) continue;
-    // Simple split — domain names don't contain commas or quotes
-    const cols = line.split(',');
-    const domain = cols[domainIndex] ? cols[domainIndex].trim() : null;
-    if (domain) {
-      domains.add(domain);
-    }
-  }
-
-  return domains;
-}
-
-/**
  * Fetches the all_sites CSV and returns a Map of domain →
- *   { allNull: boolean, classification: object|null }.
- * - allNull is true when all 8 privacy-signal columns are null/empty, meaning
- *   we could not observe any consent mechanism to measure GPC compliance against.
- * - classification is the parsed `compliance_classification` JSON object when
- *   the column is present and parseable, otherwise null.
- * @param {string} url - Direct download URL for the all_sites CSV
- * @returns {Promise<Map<string, {allNull: boolean, classification: object|null}>>}
+ * { classification: object|null }.
  */
 async function fetchAllSitesData(url) {
   const response = await fetch(url);
@@ -231,9 +118,7 @@ async function fetchAllSitesData(url) {
     throw new Error('all_sites CSV does not contain a "domain" column');
   }
 
-  // Map each signal column name to its index (-1 if not present)
-  const signalIndices = SIGNAL_COLUMNS.map(col => headers.indexOf(col));
-  const classificationIndex = headers.indexOf('compliance_classification');
+  const classificationIndex = headers.indexOf('complianceclassification');
 
   const result = new Map();
   for (let i = 1; i < lines.length; i++) {
@@ -241,12 +126,7 @@ async function fetchAllSitesData(url) {
     if (!line || !line.trim()) continue;
     const cols = parseCSVLine(line);
     const domain = cols[domainIndex] ? cols[domainIndex].trim() : null;
-    // Skip rows where domain itself is missing or the literal string "null"
-    // (happens when the crawler couldn't resolve the domain, e.g. status="not added")
     if (!domain || domain.toLowerCase() === 'null') continue;
-
-    // A domain is allNull only if every signal column is null/empty
-    const allNull = signalIndices.every(idx => idx === -1 || isNullSignal(cols[idx]));
 
     let classification = null;
     if (classificationIndex !== -1) {
@@ -256,7 +136,7 @@ async function fetchAllSitesData(url) {
       }
     }
 
-    result.set(domain, { allNull, classification });
+    result.set(domain, { classification });
   }
 
   return result;
@@ -264,18 +144,6 @@ async function fetchAllSitesData(url) {
 
 /**
  * Fetches and processes compliance data for a specific state.
- * First fetches states.json from the remote host to get current CSV URLs,
- * then fetches both all_sites and noncompliant_sites CSVs in parallel.
- * Determines status by set membership and signal content:
- *   - in noncompliant_sites              → 'non_compliant'
- *   - in all_sites, signals detected     → 'compliant'
- *   - in all_sites, all signals null     → 'no_signals'
- * Domains absent from all_sites are not included in the returned map;
- * the caller treats missing entries as 'no_data'.
- * Any network or server error returns { error: 'fetch_error' }.
- *
- * @param {string} stateCode - Two-letter state code (CA, CO, CT, NJ)
- * @returns {Promise<Object>} - { data, fetchedAt, stateCode, count } or { error: 'fetch_error' }
  */
 export async function fetchComplianceData(stateCode) {
   const stateName = STATE_NAMES[stateCode];
@@ -283,7 +151,6 @@ export async function fetchComplianceData(stateCode) {
     throw new Error(`Unknown state code: ${stateCode}`);
   }
 
-  // Fetch states.json from the remote host to get current CSV URLs
   let statesConfig;
   try {
     statesConfig = await fetchStatesConfig();
@@ -293,52 +160,36 @@ export async function fetchComplianceData(stateCode) {
   }
 
   const stateEntry = statesConfig[stateName];
-  if (!stateEntry || !stateEntry.all_sites || !stateEntry.noncompliant_sites) {
+  if (!stateEntry || !stateEntry.all_sites) {
     console.error(`states.json does not contain a valid entry for: ${stateName}`);
     return { error: 'fetch_error' };
   }
 
-  // Convert GitHub blob URLs from states.json to raw content URLs
-  let allSitesUrl, noncompliantUrl;
+  let allSitesUrl;
   try {
     allSitesUrl = toRawUrl(stateEntry.all_sites);
-    noncompliantUrl = toRawUrl(stateEntry.noncompliant_sites);
   } catch (error) {
     console.error('Failed to parse CSV URLs from states.json:', error);
     return { error: 'fetch_error' };
   }
 
-  console.log(`Fetching ${stateCode} compliance data (all_sites + noncompliant_sites)...`);
+  console.log(`Fetching ${stateCode} compliance data (all_sites)...`);
 
-  let allSitesData, noncompliantDomains;
+  let allSitesData;
   try {
-    [allSitesData, noncompliantDomains] = await Promise.all([
-      fetchAllSitesData(allSitesUrl),
-      fetchDomainSet(noncompliantUrl),
-    ]);
+    allSitesData = await fetchAllSitesData(allSitesUrl);
   } catch (error) {
     console.error(`Failed to fetch compliance CSVs for ${stateCode}:`, error);
     return { error: 'fetch_error' };
   }
 
-  console.log(`${stateCode}: ${allSitesData.size} all_sites, ${noncompliantDomains.size} noncompliant_sites`);
+  console.log(`${stateCode}: ${allSitesData.size} all_sites processed`);
 
   const complianceMap = {};
 
-  for (const [domain, { allNull, classification }] of allSitesData) {
-    let status;
-    if (noncompliantDomains.has(domain)) {
-      status = 'non_compliant';
-    } else if (allNull) {
-      // All 8 signal columns were null during the crawl — we can't assess compliance
-      status = 'no_signals';
-    } else {
-      status = 'compliant';
-    }
+  for (const [domain, { classification }] of allSitesData) {
     complianceMap[domain] = {
-      status,
-      details: '',
-      classification, // null when CSV lacks the column or value is JSON null
+      classification // null when CSV lacks the column or value is JSON null
     };
   }
 
@@ -350,11 +201,6 @@ export async function fetchComplianceData(stateCode) {
   };
 }
 
-/**
- * Checks if cached data is still valid
- * @param {number} fetchedAt - Timestamp when data was fetched
- * @returns {boolean} - True if cache is still valid
- */
 export function isCacheValid(fetchedAt) {
   if (!fetchedAt) return false;
   return (Date.now() - fetchedAt) < CACHE_TTL_MS;

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -824,7 +824,7 @@ function overallBadgeHtml(classification) {
     return '<span class="compliance-status-badge compliance-non-compliant">🔴 Likely Does Not Honor GPC</span>';
   }
   
-  // Catches 'Not Applicable/Invalid/Missing' or undefined
+  // Catches both 'Not Applicable/Invalid/Missing' and 'null'
   return '<span class="compliance-status-badge compliance-no-signals">🟡 Could Not Determine</span>';
 }
 

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -760,11 +760,11 @@ async function buildComplianceStatusLoading(stateCode) {
 // Maps a schema status string to a (label, css class) for the status pill.
 // `null`/missing means no privacy string of that family was detected.
 const CLASSIFICATION_STATUS_META = {
-  opted_out:        { label: 'Opted Out',        cls: 'status-opted-out' },
-  did_not_opt_out:  { label: 'Did Not Opt Out',  cls: 'status-did-not-opt-out' },
-  invalid_missing:  { label: 'Invalid/Missing',  cls: 'status-invalid' },
-  invalid:          { label: 'Invalid',          cls: 'status-invalid' },
-  not_applicable:   { label: 'Not Applicable',   cls: 'status-na' },
+  'Opted Out':        { label: 'Opted Out',        cls: 'status-opted-out' },
+  'Did Not Opt Out':  { label: 'Did Not Opt Out',  cls: 'status-did-not-opt-out' },
+  'Invalid/Missing':  { label: 'Invalid/Missing',  cls: 'status-invalid' },
+  'Invalid':          { label: 'Invalid',          cls: 'status-invalid' },
+  'Not Applicable':   { label: 'Not Applicable',   cls: 'status-na' },
 };
 const CLASSIFICATION_NONE_META  = { label: 'None',  cls: 'status-none' };
 const CLASSIFICATION_MIXED_META = { label: 'Mixed', cls: 'status-mixed' };
@@ -776,13 +776,13 @@ function metaForStatus(status) {
   return CLASSIFICATION_STATUS_META[status] || { label: 'Unknown', cls: 'status-none' };
 }
 
-// GPP ships a list of per-(state, field) classifications. Collapse to one
-// status: same across all → that status; different → "Mixed".
+// GPP ships a list of per-(section, field) classifications. Collapse to one
+// complianceClassification: same across all → that classification; different → "Mixed".
 function aggregateGppMeta(gpp) {
-  if (!gpp || !Array.isArray(gpp.classifications) || gpp.classifications.length === 0) {
+  if (!gpp || !Array.isArray(gpp.complianceClassifications) || gpp.complianceClassifications.length === 0) {
     return CLASSIFICATION_NONE_META;
   }
-  const statuses = new Set(gpp.classifications.map(c => c.status));
+  const statuses = new Set(gpp.complianceClassifications.map(c => c.complianceClassification));
   if (statuses.size === 1) return metaForStatus([...statuses][0]);
   return CLASSIFICATION_MIXED_META;
 }
@@ -797,73 +797,66 @@ function classificationRowHtml(family, meta) {
 }
 
 function buildClassificationHtml(classification) {
+  // Helper to safely extract the string, whether it's nested or a raw string like
+  const getClassification = (field) => {
+    if (!field || field === "None") return null; // null is the convention used by metaForStatus
+    return typeof field === 'string' ? field : field.complianceClassification;
+  };
+
   return `
     <div class="compliance-classifications">
-      ${classificationRowHtml('USPS',            metaForStatus(classification.usps?.status))}
-      ${classificationRowHtml('Optanon Consent', metaForStatus(classification.optanonConsent?.status))}
-      ${classificationRowHtml('Well-known',      metaForStatus(classification.wellKnown?.status))}
+      ${classificationRowHtml('USPS',            metaForStatus(getClassification(classification.usps)))}
+      ${classificationRowHtml('Optanon Consent', metaForStatus(getClassification(classification.optanonConsent)))}
+      ${classificationRowHtml('Well-known',      metaForStatus(getClassification(classification.wellKnown)))}
       ${classificationRowHtml('GPP',             aggregateGppMeta(classification.gpp))}
     </div>
   `;
 }
 
-// Roll the four families (GPP flattened) into a single top-line verdict:
-// any did_not_opt_out → "does_not_honor"; else any opted_out → "honors";
-// else "unknown" (all None, or only invalid/not_applicable).
-function computeOverallVerdict(classification) {
-  const statuses = [];
-  if (classification.usps?.status)            statuses.push(classification.usps.status);
-  if (classification.optanonConsent?.status)  statuses.push(classification.optanonConsent.status);
-  if (classification.wellKnown?.status)       statuses.push(classification.wellKnown.status);
-  if (Array.isArray(classification.gpp?.classifications)) {
-    for (const c of classification.gpp.classifications) {
-      if (c.status) statuses.push(c.status);
-    }
-  }
-  if (statuses.includes('did_not_opt_out')) return 'does_not_honor';
-  if (statuses.includes('opted_out'))       return 'honors';
-  return 'unknown';
-}
-
 function overallBadgeHtml(classification) {
-  const verdict = computeOverallVerdict(classification);
-  if (verdict === 'honors') {
+  // Extract the pre-calculated verdict directly from the new schema
+  const verdict = classification?.complianceResult;
+
+  if (verdict === 'Likely Honors GPC') {
     return '<span class="compliance-status-badge compliance-compliant">🟢 Likely Honors GPC</span>';
   }
-  if (verdict === 'does_not_honor') {
+  if (verdict === 'Likely Does Not Honor GPC') {
     return '<span class="compliance-status-badge compliance-non-compliant">🔴 Likely Does Not Honor GPC</span>';
   }
+  
+  // Catches 'Not Applicable/Invalid/Missing' or undefined
   return '<span class="compliance-status-badge compliance-no-signals">🟡 Could Not Determine</span>';
 }
 
 /**
  * Builds the Compliance Status HTML for the popup window
- * @param {Object} status - Compliance status object from storage
+ * @param {Object} complianceRecord - Compliance record object from storage
  * @param {string} stateCode - The state code
  */
-async function buildComplianceStatus(status, stateCode) {
+async function buildComplianceStatus(complianceRecord, stateCode) {
   const container = document.getElementById("compliance-status-content");
   const stateName = STATE_NAMES[stateCode] || stateCode;
-  // Link to the gpc-web-ui pre-filtered to this state (and the current site
-  // when known) via its URL parameter API (`state`, `url`).
+  
   const params = new URLSearchParams({ state: stateCode });
   if (parsedDomain) params.set('url', parsedDomain);
   const datasetUrl = `https://gpc-web-ui.vercel.app/?${params.toString()}`;
   const stateLabel = `<p class="compliance-state-label">What We Observed · ${stateName}</p>`;
 
-  if (!status || status.status === 'no_data') {
+  // 1. Handle missing data (Not in Dataset)
+  if (!complianceRecord || complianceRecord._isMissing) {
     container.innerHTML = `
       <div class="compliance-inline">
         ${stateLabel}
         <span class="compliance-status-badge compliance-no-data">⚪ Not in Dataset</span>
-        <p class="compliance-status-text">We do not have data for this site.</p>
+        <p class="compliance-status-text">${complianceRecord?.details || 'We do not have data for this site.'}</p>
         <a class="compliance-link" href="${datasetUrl}" target="_blank">View ${stateName} dataset →</a>
       </div>
     `;
     return;
   }
 
-  if (status.status === 'fetch_error') {
+  // 2. Handle network/server errors
+  if (complianceRecord._fetchError) {
     container.innerHTML = `
       <div class="compliance-inline">
         ${stateLabel}
@@ -874,45 +867,25 @@ async function buildComplianceStatus(status, stateCode) {
     return;
   }
 
-  // New schema-based per-family classification (preferred when the dataset has it).
-  if (status.classification) {
+  // 3. Render the new schema!
+  if (complianceRecord.classification) {
     container.innerHTML = `
       <div class="compliance-inline">
         ${stateLabel}
-        ${overallBadgeHtml(status.classification)}
-        ${buildClassificationHtml(status.classification)}
+        ${overallBadgeHtml(complianceRecord.classification)}
+        ${buildClassificationHtml(complianceRecord.classification)}
         <a class="compliance-link" href="${datasetUrl}" target="_blank">View ${stateName} dataset →</a>
       </div>
     `;
     return;
   }
 
-  // Fallback: legacy summary badge for datasets without the classification column.
-  let badge = '';
-  let statusText = '';
-  if (status.status === 'compliant') {
-    badge = '<span class="compliance-status-badge compliance-compliant">🟢 Likely Honors GPC</span>';
-    statusText = '';
-  } else if (status.status === 'non_compliant') {
-    badge = '<span class="compliance-status-badge compliance-non-compliant">🔴 Likely Ignores GPC</span>';
-    statusText = 'This site has consent tools but did not appear to respond to GPC during our crawl.';
-  } else if (status.status === 'no_signals') {
-    badge = '<span class="compliance-status-badge compliance-no-signals">🟡 Could Not Determine</span>';
-    statusText = 'No consent signals were detected on this site during our crawl, so we cannot assess GPC compliance.';
-  } else {
-    badge = '<span class="compliance-status-badge compliance-unknown">🔵 Inconclusive</span>';
-    statusText = 'This site is in the dataset but results were inconclusive.';
-  }
-
-  const details = status.details || '';
-
+  // Fallback catch-all if classification is mysteriously null
   container.innerHTML = `
     <div class="compliance-inline">
       ${stateLabel}
-      ${badge}
-      <p class="compliance-status-text">${statusText}</p>
-      ${details ? `<p class="compliance-details">${details}</p>` : ''}
-      <a class="compliance-link" href="${datasetUrl}" target="_blank">View ${stateName} dataset →</a>
+      <span class="compliance-status-badge compliance-no-signals">🟡 Could Not Determine</span>
+      <p class="compliance-status-text">Data structure was malformed or missing classification.</p>
     </div>
   `;
 }


### PR DESCRIPTION
### Changes
Modified popup.js to use schema 1.1.0's [new language](https://github.com/privacy-tech-lab/gpc-web-crawler/issues/297#issuecomment-4812493340) + reference [`complianceResult`](https://github.com/privacy-tech-lab/gpc-web-crawler/issues/275) when displaying compliance classification. 

Other modifications were made to `complainceData.js` and `protection.js` to remove legacy debt (mostly caused by the transition away from "noncompliant_sites.csv"‎ files). The main change is that we no longer locally determine a compliance "status" and put it into storage. Instead the entire complianceClassification schema is put into storage so that popup.js can fetch it when needed.

### Important Note On Merging
The last thing worth mentioning is that the `STATES_JSON_URL` (from complianceData.js) references a local copy of the web-ui repo I made for testing. While it works currently, we should change the URL to reference the main web-ui repo after [States.json](https://github.com/privacy-tech-lab/gpc-web-ui/blob/main/client/public/states.json) is updated. In other words, merging will have to wait until the [related UI issue](https://github.com/privacy-tech-lab/gpc-web-ui/issues/100) is closed. 