### PR TITLE
Remove NJ elements and logic

### DIFF
--- a/src/data/complianceData.js
+++ b/src/data/complianceData.js
@@ -25,7 +25,6 @@ export const STATE_NAMES = {
   CA: 'California',
   CO: 'Colorado',
   CT: 'Connecticut',
-  NJ: 'New Jersey',
 };
 
 // Cache TTL: 24 hours

--- a/src/options/views/settings-view/settings-view.html
+++ b/src/options/views/settings-view/settings-view.html
@@ -148,7 +148,6 @@ options page when clicked
               <option value="CA">California</option>
               <option value="CO">Colorado</option>
               <option value="CT">Connecticut</option>
-              <option value="NJ">New Jersey</option>
             </select>
           </div>
         </div>

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -33,7 +33,6 @@ popup.html is the html scaffolding for OptMeowt's popup page
         <button class="state-btn" data-state="CA">🌴 California</button>
         <button class="state-btn" data-state="CO">🏔️ Colorado</button>
         <button class="state-btn" data-state="CT">🌳 Connecticut</button>
-        <button class="state-btn" data-state="NJ">🏖️ New Jersey</button>
       </div>
       <button id="state-skip-link" class="state-btn state-btn-skip">Skip — I'm not in these states</button>
     </div>


### PR DESCRIPTION
Removes all elements related to "NJ" and "New Jersey" (closes #613).

I ran a keyword search for "NJ" and "New Jersey" and removed the element associated with each appearance. My local testing didn't reveal any broken logic as a result of these changes, but I'd like another pair of eyes before we merge this and create a release. 

@mccoogp could you please build locally to make sure there is no NJ-related behavior remaining?