### PR TITLE
Bump version numbers for 6.3.0 release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "optmeowt",
-  "version": "6.2.0",
+  "version": "6.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "optmeowt",
-      "version": "6.2.0",
+      "version": "6.3.0",
       "license": "ISC",
       "dependencies": {
         "animate.css": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "optmeowt",
-  "version": "6.2.0",
+  "version": "6.3.0",
   "description": "A privacy extension that allows users to exercise rights under GPC",
   "main": "index.js",
   "type": "module",

--- a/src/manifests/chrome/manifest-dev.json
+++ b/src/manifests/chrome/manifest-dev.json
@@ -1,7 +1,7 @@
 {
   "name": "OptMeowt",
   "author": "privacy-tech-lab",
-  "version": "6.2.0",
+  "version": "6.3.0",
   "description": "OptMeowt allows Web users to make use of their rights to opt out from the sale and sharing of personal data",
   "permissions": [
     "declarativeNetRequest",

--- a/src/manifests/chrome/manifest-dist.json
+++ b/src/manifests/chrome/manifest-dist.json
@@ -1,7 +1,7 @@
 {
   "name": "OptMeowt",
   "author": "privacy-tech-lab",
-  "version": "6.2.0",
+  "version": "6.3.0",
   "description": "OptMeowt allows Web users to make use of their rights to opt out from the sale and sharing of personal data",
   "permissions": [
     "declarativeNetRequest",

--- a/src/manifests/firefox/manifest-dev.json
+++ b/src/manifests/firefox/manifest-dev.json
@@ -1,7 +1,7 @@
 {
   "name": "OptMeowt",
   "author": "privacy-tech-lab",
-  "version": "6.2.0",
+  "version": "6.3.0",
   "description": "OptMeowt allows Web users to make use of their rights to opt out from the sale and sharing of personal data",
   "permissions": [
     "webRequestBlocking",

--- a/src/manifests/firefox/manifest-dist.json
+++ b/src/manifests/firefox/manifest-dist.json
@@ -1,7 +1,7 @@
 {
   "name": "OptMeowt",
   "author": "privacy-tech-lab",
-  "version": "6.2.0",
+  "version": "6.3.0",
   "description": "OptMeowt allows Web users to make use of their rights to opt out from the sale and sharing of personal data",
   "permissions": [
     "webRequestBlocking",


### PR DESCRIPTION
Bumps all version numbers from "6.2.0" to "6.3.0".

Very quick bump to the version numbers before I create the new release. Considering it's such a small change, I'll self-approve. Just wanted to document this change in a PR.